### PR TITLE
Add support for submission history

### DIFF
--- a/src/main/java/edu/ksu/canvas/model/assignment/Submission.java
+++ b/src/main/java/edu/ksu/canvas/model/assignment/Submission.java
@@ -36,6 +36,7 @@ public class Submission extends BaseCanvasModel implements Serializable {
     private Boolean assigmentVisible;
     private Boolean excused;
     private String workflowState;
+    private List<Submission> submissionHistory;
 
     public Integer getId() {
         return id;
@@ -212,6 +213,14 @@ public class Submission extends BaseCanvasModel implements Serializable {
 
     public void setWorkflowState(String workflowState) {
         this.workflowState = workflowState;
+    }
+
+    public List<Submission> getSubmissionHistory(){
+        return this.submissionHistory;
+    }
+
+    public void setSubmissionHistory(List<Submission> submissionHistory) {
+        this.submissionHistory = submissionHistory;
     }
 
 }

--- a/src/main/java/edu/ksu/canvas/requestOptions/GetSubmissionsOptions.java
+++ b/src/main/java/edu/ksu/canvas/requestOptions/GetSubmissionsOptions.java
@@ -10,8 +10,8 @@ public class GetSubmissionsOptions extends BaseOptions {
 
     public enum Include {
         //Submissions can optionally have sub-objects returned with them. The commented out ones are not implemented yet
-        //SUBMISSION_HISTORY, RUBRIC_ASSESSMENT, GROUP
-        ASSIGNMENT, COURSE, SUBMISSION_COMMENTS, USER, VISIBILITY;
+        // RUBRIC_ASSESSMENT, GROUP
+        ASSIGNMENT, COURSE, SUBMISSION_COMMENTS, USER, VISIBILITY, SUBMISSION_HISTORY;
 
         public String toString() {
             return name().toLowerCase();


### PR DESCRIPTION
A feature I contributed to the Kansas State project 8 months ago, ignored since then:

https://github.com/kstateome/canvas-api/pull/122

Not a problem ignoring and closing it.