### PR TITLE
Fix for course ID not being URL safe.

### DIFF
--- a/src/main/java/edu/ksu/canvas/impl/BaseImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/BaseImpl.java
@@ -18,7 +18,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Type;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -124,6 +127,15 @@ public abstract class BaseImpl<T, READERTYPE extends CanvasReader, WRITERTYPE ex
         this.masqueradeAs = masqueradeAs;
         this.masqueradeType = masqueradeType;
         return (WRITERTYPE) this;
+    }
+
+    protected String encode(String value) {
+        try {
+            // TODO On Java 10+ drop the toString() and try/catch
+            return URLEncoder.encode(value, StandardCharsets.UTF_8.toString());
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException("Failed to encode as UTF-8", e);
+        }
     }
 
     protected String buildCanvasUrl(String canvasMethod, Map<String, List<String>> parameters) {

--- a/src/main/java/edu/ksu/canvas/impl/CourseImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/CourseImpl.java
@@ -96,7 +96,8 @@ public class CourseImpl extends BaseImpl<Course, CourseReader, CourseWriter> imp
     @Override
     public Optional<Course> updateCourse(String id, Course course) throws IOException {
         LOG.debug("updating course");
-        String url = buildCanvasUrl("courses/" + id, Collections.emptyMap());
+        // TODO At some point we need to sort this out better throughout the library
+        String url = buildCanvasUrl("courses/" + encode(id), Collections.emptyMap());
         Response response = canvasMessenger.sendJsonPutToCanvas(oauthToken, url, course.toJsonObject(serializeNulls));
         return responseParser.parseToObject(Course.class, response);
     }


### PR DESCRIPTION
If the course ID (eg SIS ID) isn’t URL safe then it should have been encoded. This makes sure we do that encoding.