### PR TITLE
Correctly handle Instructure cookies.

### DIFF
--- a/src/main/java/edu/ksu/canvas/net/SimpleRestClient.java
+++ b/src/main/java/edu/ksu/canvas/net/SimpleRestClient.java
@@ -18,6 +18,7 @@ import org.apache.http.HttpHeaders;
 import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.CookieSpecs;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -400,6 +401,7 @@ public class SimpleRestClient implements RestClient {
         RequestConfig config = RequestConfig.custom()
                 .setConnectTimeout(connectTimeout)
                 .setSocketTimeout(readTimeout)
+                .setCookieSpec(CookieSpecs.STANDARD)
                 .build();
         return HttpClientBuilder.create()
                 .setDefaultRequestConfig(config);


### PR DESCRIPTION
When a file is uploaded to Canvas they send back a cookie and the parser fails to understand this and generates an warning in the logs. This switches us to use the standard cookie parser which understands the cookie without a warning.