### PR TITLE
Course Archiving: Support override stickyness

### DIFF
--- a/src/main/java/edu/ksu/canvas/requestOptions/CreateSisImportOptions.java
+++ b/src/main/java/edu/ksu/canvas/requestOptions/CreateSisImportOptions.java
@@ -19,8 +19,12 @@ public class CreateSisImportOptions extends BaseOptions {
     private final String filePath;
     private final InputStream is;
     private final ImportType importType;
-    
+
     public CreateSisImportOptions(String accountId, String filePath, ImportType importType, String diffingDataSetIdentifier, InputStream is) {
+        this(accountId, filePath, importType, diffingDataSetIdentifier, is, false);
+    }
+
+    public CreateSisImportOptions(String accountId, String filePath, ImportType importType, String diffingDataSetIdentifier, InputStream is, boolean overrideSisStickiness) {
         this.accountId = accountId;
         this.importType = importType;
         this.filePath = filePath;
@@ -28,6 +32,9 @@ public class CreateSisImportOptions extends BaseOptions {
         addSingleItem("import_type", importType.toString().toLowerCase());
         if(diffingDataSetIdentifier != null) {
             addSingleItem("diffing_data_set_identifier", diffingDataSetIdentifier);
+        }
+        if (overrideSisStickiness) {
+            addSingleItem("override_sis_stickiness", Boolean.toString(overrideSisStickiness));
         }
     }
 
@@ -46,4 +53,5 @@ public class CreateSisImportOptions extends BaseOptions {
     public ImportType getImportType() {
         return importType;
     }
+
 }


### PR DESCRIPTION
@buckett I needed to support this in order to delete courses via sisImport, sisImports are ignoring me because looks like the status is a sticky field.

Required in https://github.com/oxctl/canvas-course-archiving/pull/3