### PR TITLE
Make CanvasTestBase abstract

### DIFF
--- a/src/test/java/edu/ksu/canvas/CanvasTestBase.java
+++ b/src/test/java/edu/ksu/canvas/CanvasTestBase.java
@@ -15,7 +15,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = {CommonTestConfig.class})
 @ActiveProfiles("dev")
-public class CanvasTestBase {
+public abstract class CanvasTestBase {
     public static final OauthToken SOME_OAUTH_TOKEN = new NonRefreshableOauthToken("token");;
     public static final int SOME_CONNECT_TIMEOUT = 1000;
     public static final int SOME_READ_TIMEOUT = 1000;


### PR DESCRIPTION
Although this doesn’t get run as a test under maven when using IntelliJ it attempts to run this class as a test which then fails, marking it as abstract means it should never get run by IntelliJ, but also allows it to continue to be used as before.