### PR TITLE
Switch the user class ID to be a long.

### DIFF
--- a/src/main/java/edu/ksu/canvas/model/User.java
+++ b/src/main/java/edu/ksu/canvas/model/User.java
@@ -16,7 +16,7 @@ import java.util.Objects;
 public class User extends BaseCanvasModel implements Serializable {
     private static final long serialVersionUID = 2L;
 
-    private int id;
+    private long id;
     private String name;
     private String sortableName;
     private String shortName;
@@ -58,11 +58,11 @@ public class User extends BaseCanvasModel implements Serializable {
 
     }
 
-    public int getId() {
+    public long getId() {
         return id;
     }
 
-    public void setId(int id) {
+    public void setId(long id) {
         this.id = id;
     }
 

--- a/src/main/java/edu/ksu/canvas/model/assignment/QuizSubmissionResponse.java
+++ b/src/main/java/edu/ksu/canvas/model/assignment/QuizSubmissionResponse.java
@@ -21,7 +21,7 @@ import java.util.stream.Collectors;
  */
 public class QuizSubmissionResponse {
     private final List<QuizSubmission> quizSubmissions;
-    private final Map<Integer, User> users;
+    private final Map<Long, User> users;
     private final Map<Integer, Quiz> quizzes;
 
     public QuizSubmissionResponse(final List<QuizSubmission> quizSubmissions, final List<User> users, final List<Quiz> quizzes) {
@@ -43,7 +43,7 @@ public class QuizSubmissionResponse {
      * if users were requested via GetQuizSubmissionsOptions
      * @return User map
      */
-    public Map<Integer, User> getUsers() {
+    public Map<Long, User> getUsers() {
         return users;
     }
 
@@ -52,7 +52,7 @@ public class QuizSubmissionResponse {
      * @param userId Canvas user ID
      * @return Canvas user record if found
      */
-    public Optional<User> getUser(final int userId) {
+    public Optional<User> getUser(final long userId) {
         return Optional.ofNullable(users.get(userId));
     }
 

--- a/src/test/java/edu/ksu/canvas/tests/quiz/QuizSubmissionRetrieverUTest.java
+++ b/src/test/java/edu/ksu/canvas/tests/quiz/QuizSubmissionRetrieverUTest.java
@@ -78,7 +78,7 @@ public class QuizSubmissionRetrieverUTest extends CanvasTestBase {
         Assert.assertEquals(2, response.getQuizSubmissions().size());
         Assert.assertEquals(2, response.getUsers().size());
         Assert.assertEquals((Integer) 508566, response.getQuizSubmissions().get(0).getId());
-        Assert.assertEquals("User 218826", response.getUser(218826).get().getName());
+        Assert.assertEquals("User 218826", response.getUser(218826L).get().getName());
     }
 
     @Test

--- a/src/test/java/edu/ksu/canvas/tests/user/UserRetrieverUTest.java
+++ b/src/test/java/edu/ksu/canvas/tests/user/UserRetrieverUTest.java
@@ -89,6 +89,16 @@ public class UserRetrieverUTest extends CanvasTestBase {
     }
 
     @Test
+    public void testShowUserDetailsByUserIdLong() throws Exception {
+        long userId = 123450000000000020L;
+        String url = baseUrl + "/api/v1/users/" + String.valueOf(userId);
+        fakeRestClient.addSuccessResponse(url, "SampleJson/user/UserByIdLong.json");
+        Optional<User> result = userReader.showUserDetails(String.valueOf(userId));
+        User user = result.get();
+        Assert.assertEquals(userId, user.getId());
+    }
+
+    @Test
     public void testShowUserDetailsBySisUserId() throws Exception {
         int userId = 31;
         String sisUserId = "sis_user_id:ABC123";

--- a/src/test/java/edu/ksu/canvas/tests/user/UserRetrieverUTest.java
+++ b/src/test/java/edu/ksu/canvas/tests/user/UserRetrieverUTest.java
@@ -90,6 +90,7 @@ public class UserRetrieverUTest extends CanvasTestBase {
 
     @Test
     public void testShowUserDetailsByUserIdLong() throws Exception {
+        // When users exist from multiple instances the IDs can become very long (larger than an int).
         long userId = 123450000000000020L;
         String url = baseUrl + "/api/v1/users/" + String.valueOf(userId);
         fakeRestClient.addSuccessResponse(url, "SampleJson/user/UserByIdLong.json");

--- a/src/test/resources/SampleJson/user/UserByIdLong.json
+++ b/src/test/resources/SampleJson/user/UserByIdLong.json
@@ -1,0 +1,16 @@
+{
+  "id": 123450000000000020,
+  "name": "Student Number 20 in instance 12345",
+  "sortable_name": "Student, One",
+  "short_name": "StOne",
+  "sis_user_id": "Stu001",
+  "sis_import_id": 18,
+  "login_id": "student_01@numbers.example.com",
+  "avatar_url": "https://en.gravatar.com/avatar/d8cb8c8cd40ddf0cd05241443a591868?s=80&r=g",
+  "enrollments": [],
+  "email": "student_01@numbers.example.com",
+  "locale": "tlh",
+  "last_login": "2012-05-30T17:45:25Z",
+  "time_zone": "America/Denver",
+  "bio": "I am the first"
+}


### PR DESCRIPTION
In canvas IDs for users are normally small and fit into ints but under some circumstances they can become very long (when multiple canvas instances get joined together), in those situations the ID for the instance gets prefixed onto other IDs. So for example a user with an ID of 73 becomes 115370000000000073, and this no longer fits into an int.

11537 is the instance ID for the old Canvas instance.