### PR TITLE
Add confirmation_url field to User class

### DIFF
--- a/src/main/java/edu/ksu/canvas/model/User.java
+++ b/src/main/java/edu/ksu/canvas/model/User.java
@@ -33,6 +33,7 @@ public class User extends BaseCanvasModel implements Serializable {
     private String timeZone;
     private String bio;
     private Instant createdAt;
+    private String confirmationUrl;
 
     public User() {
     }
@@ -58,6 +59,7 @@ public class User extends BaseCanvasModel implements Serializable {
         this.timeZone = other.timeZone;
         this.bio = other.bio;
         this.createdAt = other.createdAt;
+        this.confirmationUrl = other.confirmationUrl;
     }
 
     public long getId() {
@@ -187,6 +189,14 @@ public class User extends BaseCanvasModel implements Serializable {
 
     public void setBio(String bio) {
         this.bio = bio;
+    }
+
+    public String getConfirmationUrl() {
+        return confirmationUrl;
+    }
+
+    public void setConfirmationUrl(String confirmationUrl) {
+        this.confirmationUrl = confirmationUrl;
     }
 
     public Instant getCreatedAt() {

--- a/src/test/java/edu/ksu/canvas/tests/course/UserManagerUTest.java
+++ b/src/test/java/edu/ksu/canvas/tests/course/UserManagerUTest.java
@@ -36,6 +36,7 @@ public class UserManagerUTest extends CanvasTestBase {
         System.out.println(response.toString());
         Assert.assertEquals("somestring4",response.get().getName());
         Assert.assertNotNull(response.get().getId());
+        Assert.assertEquals("https://instance.test.instructure.com/register/214b60f3e9c42873d323bd503f9afd4e", response.get().getConfirmationUrl());
     }
 
     @Test

--- a/src/test/resources/SampleJson/CreateUserResponse.json
+++ b/src/test/resources/SampleJson/CreateUserResponse.json
@@ -4,5 +4,6 @@
   "sortable_name": "somestring4",
   "short_name": "somestring4",
   "login_id": "somestring4",
-  "locale": null
+  "locale": null,
+  "confirmation_url": "https://instance.test.instructure.com/register/214b60f3e9c42873d323bd503f9afd4e"
 }


### PR DESCRIPTION
NOTE: As per the documentation this is the field being returned and I can see it being null in the response but I haven't been able to get a value yet, as it seems that option is only valid for account admins.