### PR TITLE
Add support for migrations by URL

### DIFF
--- a/src/main/java/edu/ksu/canvas/impl/ContentMigrationImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/ContentMigrationImpl.java
@@ -76,17 +76,17 @@ public class ContentMigrationImpl extends BaseImpl<ContentMigration, ContentMigr
     }
 
     @Override
-    public Optional<ContentMigration> createUserContentMigration(CreateContentMigrationOptions options) throws IOException {
+    public Optional<ContentMigration> createUserContentMigration(String userId, CreateContentMigrationOptions options) throws IOException {
         LOG.debug("creating user content migration");
-        String url = buildCanvasUrl("users/" + options.getSourceCourseId() + "/content_migrations", Collections.emptyMap());
+        String url = buildCanvasUrl("users/" + userId + "/content_migrations", Collections.emptyMap());
         Response response = canvasMessenger.sendToCanvas(oauthToken, url, options.getOptionsMap());
         return responseParser.parseToObject(ContentMigration.class, response);
     }
 
     @Override
-    public Optional<ContentMigration> updateUserContentMigration(Integer id, CreateContentMigrationOptions options) throws IOException {
+    public Optional<ContentMigration> updateUserContentMigration(String userId, Integer id, CreateContentMigrationOptions options) throws IOException {
         LOG.debug("updating user content migration");
-        String url = buildCanvasUrl("users/" + options.getSourceCourseId() + "/content_migrations/" + id.toString(), Collections.emptyMap());
+        String url = buildCanvasUrl("users/" + userId + "/content_migrations/" + id.toString(), Collections.emptyMap());
         Response response = canvasMessenger.putToCanvas(oauthToken, url, options.getOptionsMap());
         return responseParser.parseToObject(ContentMigration.class, response);
     }
@@ -108,17 +108,17 @@ public class ContentMigrationImpl extends BaseImpl<ContentMigration, ContentMigr
     }
 
     @Override
-    public Optional<ContentMigration> createGroupContentMigration(CreateContentMigrationOptions options) throws IOException {
+    public Optional<ContentMigration> createGroupContentMigration(String groupId, CreateContentMigrationOptions options) throws IOException {
         LOG.debug("creating group content migration");
-        String url = buildCanvasUrl("groups/" + options.getSourceCourseId() + "/content_migrations", Collections.emptyMap());
+        String url = buildCanvasUrl("groups/" + groupId + "/content_migrations", Collections.emptyMap());
         Response response = canvasMessenger.sendToCanvas(oauthToken, url, options.getOptionsMap());
         return responseParser.parseToObject(ContentMigration.class, response);
     }
 
     @Override
-    public Optional<ContentMigration> updateGroupContentMigration(Integer id, CreateContentMigrationOptions options) throws IOException {
+    public Optional<ContentMigration> updateGroupContentMigration(String groupId, Integer id, CreateContentMigrationOptions options) throws IOException {
         LOG.debug("updating group content migration");
-        String url = buildCanvasUrl("groups/" + options.getSourceCourseId() + "/content_migrations/" + id.toString(), Collections.emptyMap());
+        String url = buildCanvasUrl("groups/" + groupId + "/content_migrations/" + id.toString(), Collections.emptyMap());
         Response response = canvasMessenger.putToCanvas(oauthToken, url, options.getOptionsMap());
         return responseParser.parseToObject(ContentMigration.class, response);
     }
@@ -140,17 +140,17 @@ public class ContentMigrationImpl extends BaseImpl<ContentMigration, ContentMigr
     }
 
     @Override
-    public Optional<ContentMigration> createAccountContentMigration(CreateContentMigrationOptions options) throws IOException {
+    public Optional<ContentMigration> createAccountContentMigration(String accountId, CreateContentMigrationOptions options) throws IOException {
         LOG.debug("creating account content migration");
-        String url = buildCanvasUrl("accounts/" + options.getSourceCourseId() + "/content_migrations", Collections.emptyMap());
+        String url = buildCanvasUrl("accounts/" + accountId + "/content_migrations", Collections.emptyMap());
         Response response = canvasMessenger.sendToCanvas(oauthToken, url, options.getOptionsMap());
         return responseParser.parseToObject(ContentMigration.class, response);
     }
 
     @Override
-    public Optional<ContentMigration> updateAccountContentMigration(Integer id, CreateContentMigrationOptions options) throws IOException {
+    public Optional<ContentMigration> updateAccountContentMigration(String accountId, Integer id, CreateContentMigrationOptions options) throws IOException {
         LOG.debug("updating account content migration");
-        String url = buildCanvasUrl("accounts/" + options.getSourceCourseId() + "/content_migrations/" + id.toString(), Collections.emptyMap());
+        String url = buildCanvasUrl("accounts/" + accountId + "/content_migrations/" + id.toString(), Collections.emptyMap());
         Response response = canvasMessenger.putToCanvas(oauthToken, url, options.getOptionsMap());
         return responseParser.parseToObject(ContentMigration.class, response);
     }

--- a/src/main/java/edu/ksu/canvas/interfaces/ContentMigrationWriter.java
+++ b/src/main/java/edu/ksu/canvas/interfaces/ContentMigrationWriter.java
@@ -13,12 +13,12 @@ public interface ContentMigrationWriter extends CanvasWriter<ContentMigration, C
     Optional<ContentMigration> createCourseContentMigration(CreateCourseContentMigrationOptions options) throws IOException;
     Optional<ContentMigration> updateCourseContentMigration(Integer id, CreateCourseContentMigrationOptions options) throws IOException;
 
-    Optional<ContentMigration> createUserContentMigration(CreateContentMigrationOptions options) throws IOException;
-    Optional<ContentMigration> updateUserContentMigration(Integer id, CreateContentMigrationOptions options) throws IOException;
+    Optional<ContentMigration> createUserContentMigration(String userId, CreateContentMigrationOptions options) throws IOException;
+    Optional<ContentMigration> updateUserContentMigration(String userId, Integer id, CreateContentMigrationOptions options) throws IOException;
 
-    Optional<ContentMigration> createGroupContentMigration(CreateContentMigrationOptions options) throws IOException;
-    Optional<ContentMigration> updateGroupContentMigration(Integer id, CreateContentMigrationOptions options) throws IOException;
+    Optional<ContentMigration> createGroupContentMigration(String groupId, CreateContentMigrationOptions options) throws IOException;
+    Optional<ContentMigration> updateGroupContentMigration(String groupId, Integer id, CreateContentMigrationOptions options) throws IOException;
 
-    Optional<ContentMigration> createAccountContentMigration(CreateContentMigrationOptions options) throws IOException;
-    Optional<ContentMigration> updateAccountContentMigration(Integer id, CreateContentMigrationOptions options) throws IOException;
+    Optional<ContentMigration> createAccountContentMigration(String accountId, CreateContentMigrationOptions options) throws IOException;
+    Optional<ContentMigration> updateAccountContentMigration(String accountId, Integer id, CreateContentMigrationOptions options) throws IOException;
 }

--- a/src/main/java/edu/ksu/canvas/requestOptions/CreateContentMigrationOptions.java
+++ b/src/main/java/edu/ksu/canvas/requestOptions/CreateContentMigrationOptions.java
@@ -1,10 +1,6 @@
 package edu.ksu.canvas.requestOptions;
 
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-
-public class CreateContentMigrationOptions extends BaseOptions {
+public class CreateContentMigrationOptions<T extends CreateContentMigrationOptions<T>> extends BaseOptions {
 
     public enum MigrationType {
         course_copy_importer, zip_file_importer, common_cartridge_importer, canvas_cartridge_importer, qti_converter, moodle_converter;
@@ -14,9 +10,17 @@ public class CreateContentMigrationOptions extends BaseOptions {
 
     }
 
-    protected final String sourceCourseId;
-
     protected final MigrationType migrationType;
+
+    /**
+     * Constructs object to hold API options for the creating a content migration.
+     * A course content migration has its own options class, see CreateCourseContentMigrationOptions.
+     * @param migrationType Migration type, see enum options
+     */
+    public CreateContentMigrationOptions(MigrationType migrationType) {
+        this.migrationType = migrationType;
+        addSingleItem("migration_type", migrationType.toString().toLowerCase());
+    }
 
     /**
      * Constructs object to hold API options for the creating a content migration.
@@ -25,43 +29,43 @@ public class CreateContentMigrationOptions extends BaseOptions {
      * @param migrationType Migration type, see enum options
      */
     public CreateContentMigrationOptions(String sourceCourseId, MigrationType migrationType) {
-        this.sourceCourseId = sourceCourseId;
         this.migrationType = migrationType;
         addSingleItem("settings[source_course_id]", sourceCourseId);
         addSingleItem("migration_type", migrationType.toString().toLowerCase());
-    }
-
-    public String getSourceCourseId() {
-        return sourceCourseId;
     }
 
     public MigrationType getMigrationType() {
         return migrationType;
     }
 
-    public CreateContentMigrationOptions preAttachment(String name) {
+    /** The solution for the unchecked cast warning. */
+    protected T getThis() {
+        return (T) this;
+    }
+
+    public T preAttachment(String name) {
         addSingleItem("pre_attachment[name]", name);
-        return this;
+        return getThis();
     }
 
-    public CreateContentMigrationOptions addFileUploadProperty(String name, String value) {
+    public T addFileUploadProperty(String name, String value) {
         addSingleItem("pre_attachment["+name+"]", value);
-        return this;
+        return getThis();
     }
 
-    public CreateContentMigrationOptions fileUrl(String fileUrl) {
+    public T fileUrl(String fileUrl) {
         addSingleItem("settings[file_url]", fileUrl);
-        return this;
+        return getThis();
     }
 
-    public CreateContentMigrationOptions contentExport(String contentExportId) {
+    public T contentExport(String contentExportId) {
         addSingleItem("settings[content_export_id]", contentExportId);
-        return this;
+        return getThis();
     }
 
-    public CreateContentMigrationOptions folder(String folderId) {
+    public T folder(String folderId) {
         addSingleItem("settings[folder_id]", folderId);
-        return this;
+        return getThis();
     }
 
 }

--- a/src/main/java/edu/ksu/canvas/requestOptions/CreateCourseContentMigrationOptions.java
+++ b/src/main/java/edu/ksu/canvas/requestOptions/CreateCourseContentMigrationOptions.java
@@ -4,11 +4,20 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
-public class CreateCourseContentMigrationOptions extends CreateContentMigrationOptions {
+public class CreateCourseContentMigrationOptions extends CreateContentMigrationOptions<CreateCourseContentMigrationOptions> {
 
     private final String destinationCourseId;
 
-    private final boolean selectiveImport;
+    /**
+     * Constructs object to hold API options for the creating a course content migration.
+     *
+     * @param destinationCourseId      The id of the destination course
+     * @param migrationType            Course copy content
+     */
+    public CreateCourseContentMigrationOptions(String destinationCourseId, MigrationType migrationType) {
+        super(migrationType);
+        this.destinationCourseId = destinationCourseId;
+    }
 
     /**
      * Constructs object to hold API options for the creating a course content migration.
@@ -21,9 +30,8 @@ public class CreateCourseContentMigrationOptions extends CreateContentMigrationO
      */
     public CreateCourseContentMigrationOptions(String destinationCourseId, String sourceCourseId, MigrationType migrationType, boolean selectiveImport, String... selectedData) {
         super(sourceCourseId, migrationType);
+        this.selectiveImport(selectiveImport);
         this.destinationCourseId = destinationCourseId;
-        this.selectiveImport = selectiveImport;
-        addSingleItem("selective_import", Boolean.toString(selectiveImport));
         for(String item : selectedData) {
             addSingleItem(item, "1");
         }
@@ -32,77 +40,78 @@ public class CreateCourseContentMigrationOptions extends CreateContentMigrationO
     public String getDestinationCourseId() {
         return destinationCourseId;
     }
-
-    public boolean isSelectiveImport() {
-        return selectiveImport;
+    
+    public CreateCourseContentMigrationOptions selectiveImport(boolean selectiveImport) {
+        addSingleItem("selective_import", Boolean.toString(selectiveImport));
+        return this;
     }
 
-    public CreateContentMigrationOptions questionBank(Integer questionBankId) {
+    public CreateCourseContentMigrationOptions questionBank(Integer questionBankId) {
         addSingleItem("settings[question_bank_id]", questionBankId.toString());
         return this;
     }
 
-    public CreateContentMigrationOptions questionBankName(String questionBankName) {
+    public CreateCourseContentMigrationOptions questionBankName(String questionBankName) {
         addSingleItem("settings[question_bank_name]", questionBankName);
         return this;
     }
 
-    public CreateContentMigrationOptions overwriteQuizzes(Boolean overwriteQuizzes) {
+    public CreateCourseContentMigrationOptions overwriteQuizzes(Boolean overwriteQuizzes) {
         addSingleItem("settings[overwrite_quizzes]", overwriteQuizzes.toString());
         return this;
     }
 
-    public CreateContentMigrationOptions insertIntoModule(Integer insertIntoModuleId) {
+    public CreateCourseContentMigrationOptions insertIntoModule(Integer insertIntoModuleId) {
         addSingleItem("settings[insert_into_module_id]", insertIntoModuleId.toString());
         return this;
     }
 
-    public CreateContentMigrationOptions insertIntoModuleType(String insertIntoModuleType) {
+    public CreateCourseContentMigrationOptions insertIntoModuleType(String insertIntoModuleType) {
         addSingleItem("settings[insert_into_module_type]", insertIntoModuleType);
         return this;
     }
 
-    public CreateContentMigrationOptions insertIntoModulePosition(Integer insertIntoModulePosition) {
+    public CreateCourseContentMigrationOptions insertIntoModulePosition(Integer insertIntoModulePosition) {
         addSingleItem("settings[insert_into_module_position]", insertIntoModulePosition.toString());
         return this;
     }
 
-    public CreateContentMigrationOptions moveToAssignmentGroup(Integer moveToAssignmentGroup) {
+    public CreateCourseContentMigrationOptions moveToAssignmentGroup(Integer moveToAssignmentGroup) {
         addSingleItem("settings[move_to_assignment_group_id]", moveToAssignmentGroup.toString());
         return this;
     }
 
-    public CreateContentMigrationOptions shiftDates(Boolean shiftDates) {
+    public CreateCourseContentMigrationOptions shiftDates(Boolean shiftDates) {
         addSingleItem("date_shift_options[shift_dates]", shiftDates.toString());
         return this;
     }
 
-    public CreateContentMigrationOptions removeDates(Boolean removeDates) {
+    public CreateCourseContentMigrationOptions removeDates(Boolean removeDates) {
         addSingleItem("date_shift_options[remove_dates]", removeDates.toString());
         return this;
     }
 
-    public CreateContentMigrationOptions oldStartDate(Date oldStartDate) {
+    public CreateCourseContentMigrationOptions oldStartDate(Date oldStartDate) {
         addSingleItem("date_shift_options[old_start_date]", oldStartDate.toString());
         return this;
     }
 
-    public CreateContentMigrationOptions oldEndDate(Date oldEndDate) {
+    public CreateCourseContentMigrationOptions oldEndDate(Date oldEndDate) {
         addSingleItem("date_shift_options[old_end_date]", oldEndDate.toString());
         return this;
     }
 
-    public CreateContentMigrationOptions newStartDate(Date newStartDate) {
+    public CreateCourseContentMigrationOptions newStartDate(Date newStartDate) {
         addSingleItem("date_shift_options[new_start_date]", newStartDate.toString());
         return this;
     }
 
-    public CreateContentMigrationOptions newEndDate(Date newEndDate) {
+    public CreateCourseContentMigrationOptions newEndDate(Date newEndDate) {
         addSingleItem("date_shift_options[new_end_date]", newEndDate.toString());
         return this;
     }
 
-    public CreateContentMigrationOptions daySubstitutions(Integer dayX, Integer newDay) {
+    public CreateCourseContentMigrationOptions daySubstitutions(Integer dayX, Integer newDay) {
         addSingleItem("date_shift_options[day_substitutions]["+dayX+"]", newDay.toString());
         return this;
     }


### PR DESCRIPTION
This allows for content migrations to have a URL to import rather than a file. It also fixes the option so that we don't use the user ID to perform a import to a group or account.

This does change the API for content migrations, but it makes it clear that people shouldn't continue to use the API as it was.