### PR TITLE
Enrolment sisUserId shortcut

### DIFF
--- a/src/main/java/edu/ksu/canvas/model/Enrollment.java
+++ b/src/main/java/edu/ksu/canvas/model/Enrollment.java
@@ -39,6 +39,7 @@ public class Enrollment extends BaseCanvasModel implements Serializable {
     private Grade grades;
     private User user;
     private Long roleId;
+    private String sisUserId;
 
     public long getId() {
         return id;
@@ -237,6 +238,14 @@ public class Enrollment extends BaseCanvasModel implements Serializable {
 
     public void setUser(User user) {
         this.user = user;
+    }
+
+    public String getSisUserId() {
+        return sisUserId;
+    }
+
+    public void setSisUserId(String sisUserId) {
+        this.sisUserId = sisUserId;
     }
 
     @Override

--- a/src/test/java/edu/ksu/canvas/EnrollmentUTest.java
+++ b/src/test/java/edu/ksu/canvas/EnrollmentUTest.java
@@ -62,6 +62,7 @@ public class EnrollmentUTest extends CanvasTestBase {
         Assert.assertEquals("Expected shortName in object to match shortName in json", "Jane Doe", firstUser.getShortName());
         Assert.assertEquals("Expected sisUserId in object to match sisUserId in json", "SIS_001", firstUser.getSisUserId());
         Assert.assertEquals("Expected loginId in object to match loginId in json", "user1", firstUser.getLoginId());
+        Assert.assertEquals(firstEnrollment.getSisUserId(), firstUser.getSisUserId());
     }
 
     @Test

--- a/src/test/resources/SampleJson/Enrollments.json
+++ b/src/test/resources/SampleJson/Enrollments.json
@@ -23,6 +23,7 @@
     "course_integration_id": null,
     "sis_section_id": null,
     "section_integration_id": null,
+    "sis_user_id": "SIS_001",
     "html_url": "http://canvas.example.edu/courses/25/users/38",
     "grades": {
       "html_url": "http://canvas.example.edu/courses/25/grades/68794",
@@ -76,6 +77,7 @@
     "course_integration_id": null,
     "sis_section_id": null,
     "section_integration_id": null,
+    "sis_user_id": "SIS_002",
     "html_url": "http://canvas.example.edu/courses/25/users/68794",
     "user": {
       "id": 68794,
@@ -120,6 +122,7 @@
     "course_integration_id": null,
     "sis_section_id": null,
     "section_integration_id": null,
+    "sis_user_id": "SIS_003",
     "html_url": "http://canvas.example.edu/courses/25/users/38264",
     "user": {
       "id": 38264,


### PR DESCRIPTION
API for enrolments allows getting the sis id for the user via direct field. This lib supports it using the User field, this is just a shortcut.