### PR TITLE
Bump the Nexus plugin.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -307,7 +307,7 @@
           <plugin>
             <groupId>org.sonatype.plugins</groupId>
             <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>1.6.7</version>
+            <version>1.6.13</version>
             <extensions>true</extensions>
             <configuration>
               <serverId>ossrh</serverId>


### PR DESCRIPTION
Under Java 17 I am seeing failures with the message:

    Unable to make field private final java.util.Comparator java.util.TreeMap.comparator accessible: module java.base does not "opens java.util" to unnamed module

Downgrading to Java 11 works fine. So I'm bumping up the nexus staging plugin to see if it's been fixed later (there isn't a good changelog).