### PR TITLE
AB#92258 Add LTI Resource Link support to Canvas API client

### DIFF
--- a/src/main/java/edu/ksu/canvas/CanvasApiFactory.java
+++ b/src/main/java/edu/ksu/canvas/CanvasApiFactory.java
@@ -182,6 +182,7 @@ public class CanvasApiFactory {
         readerMap.put(MigrationIssueReader.class, MigrationIssueImpl.class);
         readerMap.put(CommunicationChannelReader.class, CommunicationChannelImpl.class);
         readerMap.put(AuthenticationLogReader.class, AuthenticationLogImpl.class);
+        readerMap.put(LtiResourceLinkReader.class, LtiResourceLinkImpl.class);
 		
         writerMap.put(AccountWriter.class, AccountImpl.class);
         writerMap.put(AssignmentOverrideWriter.class, AssignmentOverrideImpl.class);
@@ -213,5 +214,6 @@ public class CanvasApiFactory {
         writerMap.put(GradingStandardWriter.class, GradingStandardImpl.class);
         writerMap.put(SisImportWriter.class, SisImportImpl.class);
         writerMap.put(CommunicationChannelWriter.class, CommunicationChannelImpl.class);
+        writerMap.put(LtiResourceLinkWriter.class, LtiResourceLinkImpl.class);
     }
 }

--- a/src/main/java/edu/ksu/canvas/impl/LtiResourceLinkImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/LtiResourceLinkImpl.java
@@ -1,0 +1,59 @@
+package edu.ksu.canvas.impl;
+
+import com.google.gson.reflect.TypeToken;
+import edu.ksu.canvas.interfaces.LtiResourceLinkReader;
+import edu.ksu.canvas.interfaces.LtiResourceLinkWriter;
+import edu.ksu.canvas.model.LtiResourceLink;
+import edu.ksu.canvas.net.Response;
+import edu.ksu.canvas.net.RestClient;
+import edu.ksu.canvas.oauth.OauthToken;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+public class LtiResourceLinkImpl extends BaseImpl<LtiResourceLink, LtiResourceLinkReader, LtiResourceLinkWriter> implements LtiResourceLinkReader, LtiResourceLinkWriter {
+    private static final Logger LOG = LoggerFactory.getLogger(LtiResourceLinkImpl.class);
+
+    public LtiResourceLinkImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient,
+                               int connectTimeout, int readTimeout, Integer paginationPageSize, Boolean serializeNulls) {
+        super(canvasBaseUrl, apiVersion, oauthToken, restClient, connectTimeout, readTimeout,
+                paginationPageSize, serializeNulls);
+    }
+
+    @Override
+    protected Type listType() {
+        return new TypeToken<List<LtiResourceLink>>(){}.getType();
+    }
+
+    @Override
+    protected Class<LtiResourceLink> objectType() {
+        return LtiResourceLink.class;
+    }
+
+    @Override
+    public Optional<LtiResourceLink> getLtiResourceLink(String courseId, String resourceLinkId) throws IOException {
+        LOG.debug("Fetching LtiResourceLink for resourceLinkId {} in courseId {}", resourceLinkId, courseId);
+        String url = buildCanvasUrl("courses/" + courseId + "/lti_resource_links/" + resourceLinkId, Collections.emptyMap());
+        return fetchLtiResourceLink(url);
+    }
+
+    @Override
+    public Optional<LtiResourceLink> getLtiResourceLinkByUuid(String courseId, String resourceLinkUuid) throws IOException {
+        LOG.debug("Fetching LtiResourceLink for resourceLinkUuid {} in courseId {}", resourceLinkUuid, courseId);
+        String url = buildCanvasUrl("courses/" + courseId + "/lti_resource_links/resource_link_uuid:" + resourceLinkUuid, Collections.emptyMap());
+        return fetchLtiResourceLink(url);
+    }
+
+    private Optional<LtiResourceLink> fetchLtiResourceLink(String url) throws IOException {
+        Response response = canvasMessenger.getSingleResponseFromCanvas(oauthToken, url);
+        if (response.getErrorHappened() || response.getResponseCode() != 200) {
+            return Optional.empty();
+        }
+        return responseParser.parseToObject(LtiResourceLink.class, response);
+    }
+}

--- a/src/main/java/edu/ksu/canvas/interfaces/LtiResourceLinkReader.java
+++ b/src/main/java/edu/ksu/canvas/interfaces/LtiResourceLinkReader.java
@@ -1,0 +1,25 @@
+package edu.ksu.canvas.interfaces;
+import edu.ksu.canvas.model.LtiResourceLink;
+
+import java.io.IOException;
+import java.util.Optional;
+
+public interface LtiResourceLinkReader extends CanvasReader<LtiResourceLink, LtiResourceLinkReader> {
+    /**
+     * Get an LTI Resource Link by ID
+     * @param courseId The course ID
+     * @param resourceLinkId The LTI Resource Link ID
+     * @return Optional containing the LTI Resource Link if found
+     * @throws IOException When there is an error communicating with Canvas
+     */
+    Optional<LtiResourceLink> getLtiResourceLink(String courseId, String resourceLinkId) throws IOException;
+
+    /**
+     * Get an LTI Resource Link by UUID
+     * @param courseId The course ID
+     * @param resourceLinkUuid The LTI Resource Link UUID
+     * @return Optional containing the LTI Resource Link if found
+     * @throws IOException When there is an error communicating with Canvas
+     */
+    Optional<LtiResourceLink> getLtiResourceLinkByUuid(String courseId, String resourceLinkUuid) throws IOException;
+}

--- a/src/main/java/edu/ksu/canvas/interfaces/LtiResourceLinkWriter.java
+++ b/src/main/java/edu/ksu/canvas/interfaces/LtiResourceLinkWriter.java
@@ -1,0 +1,5 @@
+package edu.ksu.canvas.interfaces;
+
+import edu.ksu.canvas.model.LtiResourceLink;
+
+public interface LtiResourceLinkWriter extends CanvasWriter<LtiResourceLink, LtiResourceLinkWriter> {}

--- a/src/main/java/edu/ksu/canvas/model/LtiResourceLink.java
+++ b/src/main/java/edu/ksu/canvas/model/LtiResourceLink.java
@@ -1,0 +1,81 @@
+package edu.ksu.canvas.model;
+
+import edu.ksu.canvas.annotation.CanvasField;
+import edu.ksu.canvas.annotation.CanvasObject;
+
+import java.io.Serializable;
+
+@CanvasObject(postKey = "lti_resource_link")
+public class LtiResourceLink extends BaseCanvasModel implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private Integer id;
+    private Integer contextId;
+    private Integer contextExternalToolId;
+    private Integer associatedContentId;
+    private String contextType;
+    private String resourceType;
+    private String canvasLaunchUrl;
+    private String resourceLinkUuid;
+    private String lookupUuid;
+    private String title;
+    private String url;
+    private String lti11Id;
+    private String workflowState;
+    private String associatedContentType;
+
+    public Integer getId() { return id; }
+    public void setId(Integer id) { this.id = id; }
+
+    @CanvasField(postKey = "context_id")
+    public Integer getContextId() { return contextId; }
+    public void setContextId(Integer contextId) { this.contextId = contextId; }
+
+    @CanvasField(postKey = "context_type")
+    public String getContextType() { return contextType; }
+    public void setContextType(String contextType) { this.contextType = contextType; }
+
+    @CanvasField(postKey = "context_external_tool_id")
+    public Integer getContextExternalToolId() { return contextExternalToolId; }
+    public void setContextExternalToolId(Integer contextExternalToolId) { this.contextExternalToolId = contextExternalToolId; }
+
+    @CanvasField(postKey = "resource_type")
+    public String getResourceType() { return resourceType; }
+    public void setResourceType(String resourceType) { this.resourceType = resourceType; }
+
+    @CanvasField(postKey = "canvas_launch_url")
+    public String getCanvasLaunchUrl() { return canvasLaunchUrl; }
+    public void setCanvasLaunchUrl(String canvasLaunchUrl) { this.canvasLaunchUrl = canvasLaunchUrl; }
+
+    @CanvasField(postKey = "resource_link_uuid")
+    public String getResourceLinkUuid() { return resourceLinkUuid; }
+    public void setResourceLinkUuid(String resourceLinkUuid) { this.resourceLinkUuid = resourceLinkUuid; }
+
+    @CanvasField(postKey = "lookup_uuid")
+    public String getLookupUuid() { return lookupUuid; }
+    public void setLookupUuid(String lookupUuid) { this.lookupUuid = lookupUuid; }
+
+    @CanvasField(postKey = "title")
+    public String getTitle() { return title; }
+    public void setTitle(String title) { this.title = title; }
+
+    @CanvasField(postKey = "url")
+    public String getUrl() { return url; }
+    public void setUrl(String url) { this.url = url; }
+
+    @CanvasField(postKey = "lti_1_1_id")
+    public String getLti11Id() { return lti11Id; }
+    public void setLti11Id(String lti11Id) { this.lti11Id = lti11Id; }
+
+    @CanvasField(postKey = "workflow_state")
+    public String getWorkflowState() { return workflowState; }
+    public void setWorkflowState(String workflowState) { this.workflowState = workflowState; }
+
+    @CanvasField(postKey = "associated_content_type")
+    public String getAssociatedContentType() { return associatedContentType; }
+    public void setAssociatedContentType(String associatedContentType) { this.associatedContentType = associatedContentType; }
+
+    @CanvasField(postKey = "associated_content_id")
+    public Integer getAssociatedContentId() { return associatedContentId; }
+    public void setAssociatedContentId(Integer associatedContentId) { this.associatedContentId = associatedContentId; }
+}


### PR DESCRIPTION
 - Implement LtiResourceLink model class with required fields
 - Add reader interface with getLtiResourceLink and getLtiResourceLinkByUuid methods
 - Create implementation class with base functionality for fetching LTI Resource Links
 - Register reader and writer implementations in CanvasApiFactory

This adds support for LTI Resource Link https://canvas.instructure.com/doc/api/lti_resource_links.html to the api.