### PR TITLE
AB#113906 allow get assignment options to have string assignmentId

### DIFF
--- a/src/main/java/edu/ksu/canvas/requestOptions/GetSingleAssignmentOptions.java
+++ b/src/main/java/edu/ksu/canvas/requestOptions/GetSingleAssignmentOptions.java
@@ -5,7 +5,7 @@ import java.util.List;
 public class GetSingleAssignmentOptions extends BaseOptions {
     
     private String courseId;
-    private Integer assignmentId;
+    private String assignmentId;
 
     public enum Include {
         SUBMISSION, ASSIGNMENT_VISIBILITY, OVERRIDES, OBSERVED_USERS;
@@ -16,7 +16,7 @@ public class GetSingleAssignmentOptions extends BaseOptions {
         }
     }
 
-    public GetSingleAssignmentOptions(String courseId, Integer assignmentId) {
+    public GetSingleAssignmentOptions(String courseId, String assignmentId) {
         if(courseId == null || assignmentId == null) {
             throw new IllegalArgumentException("Course and assignment IDs are required");
         }
@@ -24,11 +24,15 @@ public class GetSingleAssignmentOptions extends BaseOptions {
         this.assignmentId = assignmentId;
     }
 
+    public GetSingleAssignmentOptions(String courseId, Integer assignmentId) {
+        this(courseId, String.valueOf(assignmentId));
+    }
+
     public String getCourseId() {
         return courseId;
     }
 
-    public Integer getAssignmentId() {
+    public String getAssignmentId() {
         return assignmentId;
     }
 

--- a/src/main/java/edu/ksu/canvas/requestOptions/GetSingleAssignmentOptions.java
+++ b/src/main/java/edu/ksu/canvas/requestOptions/GetSingleAssignmentOptions.java
@@ -25,6 +25,9 @@ public class GetSingleAssignmentOptions extends BaseOptions {
     }
 
     public GetSingleAssignmentOptions(String courseId, Integer assignmentId) {
+        if (assignmentId == null) {
+            throw new IllegalArgumentException("Course and assignment IDs are required");
+        }
         this(courseId, String.valueOf(assignmentId));
     }
 

--- a/src/main/java/edu/ksu/canvas/requestOptions/GetSingleAssignmentOptions.java
+++ b/src/main/java/edu/ksu/canvas/requestOptions/GetSingleAssignmentOptions.java
@@ -1,7 +1,6 @@
 package edu.ksu.canvas.requestOptions;
 
 import java.util.List;
-import java.util.Objects;
 
 public class GetSingleAssignmentOptions extends BaseOptions {
     
@@ -26,7 +25,10 @@ public class GetSingleAssignmentOptions extends BaseOptions {
     }
 
     public GetSingleAssignmentOptions(String courseId, Integer assignmentId) {
-        this(courseId, Objects.toString(assignmentId, null));
+        if (assignmentId == null) {
+            throw new IllegalArgumentException("Course and assignment IDs are required");
+        }
+        this(courseId, String.valueOf(assignmentId));
     }
 
     public String getCourseId() {

--- a/src/main/java/edu/ksu/canvas/requestOptions/GetSingleAssignmentOptions.java
+++ b/src/main/java/edu/ksu/canvas/requestOptions/GetSingleAssignmentOptions.java
@@ -1,6 +1,7 @@
 package edu.ksu.canvas.requestOptions;
 
 import java.util.List;
+import java.util.Objects;
 
 public class GetSingleAssignmentOptions extends BaseOptions {
     
@@ -25,10 +26,7 @@ public class GetSingleAssignmentOptions extends BaseOptions {
     }
 
     public GetSingleAssignmentOptions(String courseId, Integer assignmentId) {
-        if (assignmentId == null) {
-            throw new IllegalArgumentException("Course and assignment IDs are required");
-        }
-        this(courseId, String.valueOf(assignmentId));
+        this(courseId, Objects.toString(assignmentId, null));
     }
 
     public String getCourseId() {

--- a/src/main/java/edu/ksu/canvas/requestOptions/GetSingleAssignmentOptions.java
+++ b/src/main/java/edu/ksu/canvas/requestOptions/GetSingleAssignmentOptions.java
@@ -1,6 +1,7 @@
 package edu.ksu.canvas.requestOptions;
 
 import java.util.List;
+import java.util.Objects;
 
 public class GetSingleAssignmentOptions extends BaseOptions {
     
@@ -25,7 +26,7 @@ public class GetSingleAssignmentOptions extends BaseOptions {
     }
 
     public GetSingleAssignmentOptions(String courseId, Integer assignmentId) {
-        this(courseId, String.valueOf(assignmentId));
+        this(courseId, Objects.toString(assignmentId, null));
     }
 
     public String getCourseId() {

--- a/src/main/java/edu/ksu/canvas/requestOptions/GetSingleAssignmentOptions.java
+++ b/src/main/java/edu/ksu/canvas/requestOptions/GetSingleAssignmentOptions.java
@@ -25,9 +25,6 @@ public class GetSingleAssignmentOptions extends BaseOptions {
     }
 
     public GetSingleAssignmentOptions(String courseId, Integer assignmentId) {
-        if (assignmentId == null) {
-            throw new IllegalArgumentException("Course and assignment IDs are required");
-        }
         this(courseId, String.valueOf(assignmentId));
     }
 


### PR DESCRIPTION
Allow us to pass non-numeric ids like ~"lti_context_id:ab84f579-4442-4d4a-acd8-85c5ec6fd2b6"